### PR TITLE
Eliminate exploitable security hole in Digest->new($algorithm)

### DIFF
--- a/Digest.pm
+++ b/Digest.pm
@@ -24,24 +24,24 @@ sub new
     shift;  # class ignored
     my $algorithm = shift;
     my $impl = $MMAP{$algorithm} || do {
-	$algorithm =~ s/\W+//;
-	"Digest::$algorithm";
+        $algorithm =~ s/\W+//;
+        "Digest::$algorithm";
     };
     $impl = [$impl] unless ref($impl);
     my $err;
     for  (@$impl) {
-	my $class = $_;
-	my @args;
-	($class, @args) = @$class if ref($class);
-	no strict 'refs';
-	unless (exists ${"$class\::"}{"VERSION"}) {
-	    eval "require $class";
-	    if ($@) {
-		$err ||= $@;
-		next;
-	    }
-	}
-	return $class->new(@args, @_);
+        my $class = $_;
+        my @args;
+        ($class, @args) = @$class if ref($class);
+        no strict 'refs';
+        unless (exists ${"$class\::"}{"VERSION"}) {
+            eval "require $class";
+            if ($@) {
+                $err ||= $@;
+                next;
+            }
+        }
+        return $class->new(@args, @_);
     }
     die $err;
 }

--- a/Digest.pm
+++ b/Digest.pm
@@ -24,7 +24,7 @@ sub new
     shift;  # class ignored
     my $algorithm = shift;
     my $impl = $MMAP{$algorithm} || do {
-        $algorithm =~ s/\W+//;
+        $algorithm =~ s/\W+//g;
         "Digest::$algorithm";
     };
     $impl = [$impl] unless ref($impl);
@@ -35,7 +35,9 @@ sub new
         ($class, @args) = @$class if ref($class);
         no strict 'refs';
         unless (exists ${"$class\::"}{"VERSION"}) {
-            eval "require $class";
+            my $pm_file = $class . ".pm";
+            $pm_file =~ s{::}{/}g;
+            eval { require $pm_file };
             if ($@) {
                 $err ||= $@;
                 next;

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -5,6 +5,9 @@ WriteMakefile(
     'NAME'	   => 'Digest',
     'VERSION_FROM' => 'Digest.pm',
     ($] >= 5.008 ? ('INSTALLDIRS'  => 'perl') : ()),
-    'PREREQ_PM'    => { 'MIME::Base64' => 0, },
+    'PREREQ_PM'    => {
+        'MIME::Base64' => 0,
+        'Test::More'   => '0.47'
+    },
     'dist'         => { COMPRESS => 'gzip -9f', SUFFIX => 'gz', },
 );

--- a/t/base.t
+++ b/t/base.t
@@ -1,7 +1,6 @@
 #!perl -w
 
-use Test qw(plan ok);
-plan tests => 12;
+use Test::More tests => 12;
 
 {
    package LenDigest;
@@ -31,26 +30,26 @@ plan tests => 12;
 }
 
 my $ctx = LenDigest->new;
-ok($ctx->digest, "X0000");
+is($ctx->digest, "X0000");
 
 my $EBCDIC = ord('A') == 193;
 
 if ($EBCDIC) {
-    ok($ctx->hexdigest, "e7f0f0f0f0");
-    ok($ctx->b64digest, "5/Dw8PA");
+    is($ctx->hexdigest, "e7f0f0f0f0");
+    is($ctx->b64digest, "5/Dw8PA");
 } else {
-    ok($ctx->hexdigest, "5830303030");
-    ok($ctx->b64digest, "WDAwMDA");
+    is($ctx->hexdigest, "5830303030");
+    is($ctx->b64digest, "WDAwMDA");
 }
 
 $ctx->add("foo");
-ok($ctx->digest, "f0003");
+is($ctx->digest, "f0003");
 
 $ctx->add("foo");
-ok($ctx->hexdigest, $EBCDIC ? "86f0f0f0f3" : "6630303033");
+is($ctx->hexdigest, $EBCDIC ? "86f0f0f0f3" : "6630303033");
 
 $ctx->add("foo");
-ok($ctx->b64digest, $EBCDIC ? "hvDw8PM" : "ZjAwMDM");
+is($ctx->b64digest, $EBCDIC ? "hvDw8PM" : "ZjAwMDM");
 
 open(F, ">xxtest$$") || die;
 binmode(F);
@@ -62,23 +61,23 @@ $ctx->addfile(*F);
 close(F);
 unlink("xxtest$$") || warn;
 
-ok($ctx->digest, "a0301");
+is($ctx->digest, "a0301");
 
 eval {
     $ctx->add_bits("1010");
 };
-ok($@ =~ /^Number of bits must be multiple of 8/);
+like($@, '/^Number of bits must be multiple of 8/');
 
 $ctx->add_bits($EBCDIC ? "11100100" : "01010101");
-ok($ctx->digest, "U0001");
+is($ctx->digest, "U0001");
 
 eval {
     $ctx->add_bits("abc", 12);
 };
-ok($@ =~ /^Number of bits must be multiple of 8/);
+like($@, '/^Number of bits must be multiple of 8/');
 
 $ctx->add_bits("abc", 16);
-ok($ctx->digest, "a0002");
+is($ctx->digest, "a0002");
 
 $ctx->add_bits("abc", 32);
-ok($ctx->digest, "a0003");
+is($ctx->digest, "a0003");

--- a/t/digest.t
+++ b/t/digest.t
@@ -1,5 +1,6 @@
 print "1..3\n";
 
+use strict;
 use Digest;
 
 {
@@ -32,5 +33,3 @@ $Digest::MMAP{"Dummy-24"} = [["NotThere"], "NotThereEither", ["Digest::Dummy", 2
 $d = Digest->new("Dummy-24");
 print "not " unless $d->digest eq "24";
 print "ok 3\n";
-
-

--- a/t/digest.t
+++ b/t/digest.t
@@ -3,24 +3,10 @@
 use strict;
 use Test::More tests => 3;
 
+# To find Digest::Dummy
+use lib 't/lib';
+
 use Digest;
-
-{
-    package Digest::Dummy;
-    use vars qw($VERSION @ISA);
-    $VERSION = 1;
-
-    require Digest::base;
-    @ISA = qw(Digest::base);
-
-    sub new {
-	my $class = shift;
-	my $d = shift || "ooo";
-	bless { d => $d }, $class;
-    }
-    sub add {}
-    sub digest { shift->{d} }
-}
 
 my $d;
 $d = Digest->new("Dummy");

--- a/t/digest.t
+++ b/t/digest.t
@@ -1,6 +1,8 @@
-print "1..3\n";
+#!/usr/bin/env perl
 
 use strict;
+use Test::More tests => 3;
+
 use Digest;
 
 {
@@ -22,14 +24,11 @@ use Digest;
 
 my $d;
 $d = Digest->new("Dummy");
-print "not " unless $d->digest eq "ooo";
-print "ok 1\n";
+is $d->digest, "ooo";
 
 $d = Digest->Dummy;
-print "not " unless $d->digest eq "ooo";
-print "ok 2\n";
+is $d->digest, "ooo";
 
 $Digest::MMAP{"Dummy-24"} = [["NotThere"], "NotThereEither", ["Digest::Dummy", 24]];
 $d = Digest->new("Dummy-24");
-print "not " unless $d->digest eq "24";
-print "ok 3\n";
+is $d->digest, "24";

--- a/t/file.t
+++ b/t/file.t
@@ -1,7 +1,6 @@
 #!perl -w
 
-use Test qw(plan ok);
-plan tests => 5;
+use Test::More tests => 5;
 
 {
    package Digest::Foo;
@@ -36,17 +35,17 @@ binmode(F);
 print F "foo\0\n";
 close(F) || die "Can't write '$file': $!";
 
-ok(digest_file($file, "Foo"), "0005");
+is(digest_file($file, "Foo"), "0005");
 
 if (ord('A') == 193) { # EBCDIC.
-    ok(digest_file_hex($file, "Foo"), "f0f0f0f5");
-    ok(digest_file_base64($file, "Foo"), "8PDw9Q");
+    is(digest_file_hex($file, "Foo"), "f0f0f0f5");
+    is(digest_file_base64($file, "Foo"), "8PDw9Q");
 } else {
-    ok(digest_file_hex($file, "Foo"), "30303035");
-    ok(digest_file_base64($file, "Foo"), "MDAwNQ");
+    is(digest_file_hex($file, "Foo"), "30303035");
+    is(digest_file_base64($file, "Foo"), "MDAwNQ");
 }
 
 unlink($file) || warn "Can't unlink '$file': $!";
 
-ok(eval { digest_file("not-there.txt", "Foo") }, undef);
-ok($@);
+ok !eval { digest_file("not-there.txt", "Foo") };
+ok $@;

--- a/t/lib/Digest/Dummy.pm
+++ b/t/lib/Digest/Dummy.pm
@@ -1,0 +1,20 @@
+package Digest::Dummy;
+
+use strict;
+use vars qw($VERSION @ISA);
+$VERSION = 1;
+
+require Digest::base;
+@ISA = qw(Digest::base);
+
+sub new {
+    my $class = shift;
+    my $d = shift || "ooo";
+    bless { d => $d }, $class;
+}
+
+sub add {}
+sub digest { shift->{d} }
+
+1;
+

--- a/t/security.t
+++ b/t/security.t
@@ -1,0 +1,14 @@
+#!/usr/bin/env perl
+
+# Digest->new() had an exploitable eval
+
+use strict;
+use warnings;
+
+use Test::More tests => 1;
+
+use Digest;
+
+$LOL::PWNED = 0;
+eval { Digest->new(q[MD;5;$LOL::PWNED = 42]) };
+is $LOL::PWNED, 0;


### PR DESCRIPTION
As per https://rt.cpan.org/Ticket/Display.html?id=71390

A combination of eval "require $module" and an incomplete input filter leads to the ability to run arbitrary code via Digest->new($algorithm).

I've also...
- Converted the tests to Test::More
- Turned on strict in some tests
- Detabified some of the code
