### PR TITLE
CVE-2016-1238: prevent loading optional modules from default .

### DIFF
--- a/Digest.pm
+++ b/Digest.pm
@@ -42,7 +42,11 @@ sub new
         unless (exists ${"$class\::"}{"VERSION"}) {
             my $pm_file = $class . ".pm";
             $pm_file =~ s{::}{/}g;
-            eval { require $pm_file };
+            eval {
+                local @INC = @INC;
+                pop @INC if $INC[-1] eq '.';
+                require $pm_file;
+            };
             if ($@) {
                 $err ||= $@;
                 next;


### PR DESCRIPTION
Digest attempts to load Digest::SHA, only failing if Digest::SHA2
is also unavailable.

If a system has Digest installed, but not Digest::SHA, and a user
attempts to run a program using Digest with SHA-256 from a world
writable directory such as /tmp and since perl adds "." to the end
of @INC an attacker can run code as the original user by creating
/tmp/Digest/SHA.pm.

The change temporarily removes the default "." entry from the end of
@INC preventing that attack.
