### PR TITLE
Stop using use vars

### DIFF
--- a/Digest.pm
+++ b/Digest.pm
@@ -1,11 +1,11 @@
 package Digest;
 
 use strict;
-use vars qw($VERSION %MMAP $AUTOLOAD);
 
-$VERSION = "1.17";
+our $VERSION = "1.17";
+our $AUTOLOAD;
 
-%MMAP = (
+our %MMAP = (
   "SHA-1"      => [["Digest::SHA", 1], "Digest::SHA1", ["Digest::SHA2", 1]],
   "SHA-224"    => [["Digest::SHA", 224]],
   "SHA-256"    => [["Digest::SHA", 256], ["Digest::SHA2", 256]],

--- a/Digest/base.pm
+++ b/Digest/base.pm
@@ -1,8 +1,8 @@
 package Digest::base;
 
 use strict;
-use vars qw($VERSION);
-$VERSION = "1.16";
+
+our $VERSION = "1.16";
 
 # subclass is supposed to implement at least these
 sub new;

--- a/Digest/file.pm
+++ b/Digest/file.pm
@@ -6,10 +6,8 @@ use Exporter qw(import);
 use Carp qw(croak);
 use Digest ();
 
-use vars qw($VERSION @EXPORT_OK);
-
-$VERSION = "1.16";
-@EXPORT_OK = qw(digest_file_ctx digest_file digest_file_hex digest_file_base64);
+our $VERSION = "1.16";
+our @EXPORT_OK = qw(digest_file_ctx digest_file digest_file_hex digest_file_base64);
 
 sub digest_file_ctx {
     my $file = shift;

--- a/Digest/file.pm
+++ b/Digest/file.pm
@@ -2,14 +2,13 @@ package Digest::file;
 
 use strict;
 
-use Exporter ();
+use Exporter qw(import);
 use Carp qw(croak);
 use Digest ();
 
-use vars qw($VERSION @ISA @EXPORT_OK);
+use vars qw($VERSION @EXPORT_OK);
 
 $VERSION = "1.16";
-@ISA = qw(Exporter);
 @EXPORT_OK = qw(digest_file_ctx digest_file digest_file_hex digest_file_base64);
 
 sub digest_file_ctx {

--- a/t/base.t
+++ b/t/base.t
@@ -4,9 +4,7 @@ use Test::More tests => 13;
 
 {
    package LenDigest;
-   require Digest::base;
-   use vars qw(@ISA);
-   @ISA = qw(Digest::base);
+   use parent qw(Digest::base);
 
    sub new {
 	my $class = shift;

--- a/t/file.t
+++ b/t/file.t
@@ -4,8 +4,9 @@ use Test::More tests => 5;
 
 {
    package Digest::Foo;
-   use vars qw($VERSION);
    use parent qw(Digest::base);
+
+   our $VERSION;
 
    sub new {
 	my $class = shift;

--- a/t/file.t
+++ b/t/file.t
@@ -4,9 +4,8 @@ use Test::More tests => 5;
 
 {
    package Digest::Foo;
-   require Digest::base;
-   use vars qw(@ISA $VERSION);
-   @ISA = qw(Digest::base);
+   use vars qw($VERSION);
+   use parent qw(Digest::base);
 
    sub new {
 	my $class = shift;

--- a/t/lib/Digest/Dummy.pm
+++ b/t/lib/Digest/Dummy.pm
@@ -1,9 +1,9 @@
 package Digest::Dummy;
 
 use strict;
-use vars qw($VERSION);
 use parent qw(Digest::base);
-$VERSION = 1;
+
+our $VERSION = 1;
 
 sub new {
     my $class = shift;

--- a/t/lib/Digest/Dummy.pm
+++ b/t/lib/Digest/Dummy.pm
@@ -1,11 +1,9 @@
 package Digest::Dummy;
 
 use strict;
-use vars qw($VERSION @ISA);
+use vars qw($VERSION);
+use parent qw(Digest::base);
 $VERSION = 1;
-
-require Digest::base;
-@ISA = qw(Digest::base);
 
 sub new {
     my $class = shift;


### PR DESCRIPTION
This series switches the code away from use vars to modern alternatives, including using parent, and importing Exporter's import directly.